### PR TITLE
feat: add zero-shot prompt builder for first interview question

### DIFF
--- a/server/zeroShot.js
+++ b/server/zeroShot.js
@@ -1,0 +1,5 @@
+export function buildZeroShotPrompt(role, level, topics) {
+  const topicsStr = Array.isArray(topics) ? topics.join(', ') : String(topics)
+  return `You are an AI interviewer. Generate the FIRST interview question ONLY for Role=${role}, Level=${level}, Topics=${topicsStr}. Keep it concise. Do NOT include answers, hints, or explanation. Respond with valid JSON only and nothing else, exactly in this format:
+{"type":"interviewer","question":"<the question>"}`
+}


### PR DESCRIPTION
Title: Task #3 — Zero-Shot Prompt

Description (copy & paste and fill):

What: Added server/zeroShot.js with buildZeroShotPrompt(role, level, topics) to produce the first question using zero-shot prompting

How to test: run local server (if route added) or call LLM directly with the prompt (examples below)